### PR TITLE
setting persistenceOperations to default if null

### DIFF
--- a/core/src/main/java/com/dottydingo/hyperion/core/configuration/EntityPluginBuilder.java
+++ b/core/src/main/java/com/dottydingo/hyperion/core/configuration/EntityPluginBuilder.java
@@ -68,7 +68,7 @@ public class EntityPluginBuilder
             keyConverter = serviceRegistryBuilder.getDefaultKeyConverter();
 
         if(persistenceOperations == null)
-            serviceRegistryBuilder.getDefaultPersistenceOperations();
+            persistenceOperations = serviceRegistryBuilder.getDefaultPersistenceOperations();
 
         if(dao == null)
             dao = serviceRegistryBuilder.getDefaultDao();


### PR DESCRIPTION
Mark: When I converted the configuration of the Hyperion Sample Boot project from XML to annotations, I found this bug in the entity plugin builder. It was being masked by the parent inheritance that can only be used in XML. I've made the change here to our copy, but I thought you might want to include this fix.